### PR TITLE
GitHub Actions: Run codespell and ruff

### DIFF
--- a/.github/workflows/codespell_and_ruff.yml
+++ b/.github/workflows/codespell_and_ruff.yml
@@ -1,0 +1,20 @@
+# This Action uses minimal steps to run in ~5 seconds to rapidly:
+# look for typos in the codebase using codespell, and
+# lint Python code using ruff and provide intuitive GitHub Annotations to contributors.
+# https://github.com/codespell-project/codespell#readme
+# https://docs.astral.sh/ruff/
+name: ci
+on:
+  push:
+    # branches: [main]
+  pull_request:
+    # branches: [main]
+jobs:
+  codespell_and_ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: codespell-project/actions-codespell@v2
+    - uses: astral-sh/ruff-action@v3
+      with:
+        version: "latest"

--- a/font/hp1345.py
+++ b/font/hp1345.py
@@ -33,23 +33,20 @@ def vectorlist(wl):
 	def line(x, y):
 		ox, oy = vl[-1][-1]
 		if attr[1] in (2, 3):
-			l = math.hypot(x - ox, y - oy)
-			dx = (x - ox) / l
-			dy = (y - oy) / l
-			if attr[1] == 2:
-				dl = 400.0 / 13.0
-			else:
-				dl = 400.0 / 31.0
+			line = math.hypot(x - ox, y - oy)
+			dx = (x - ox) / line
+			dy = (y - oy) / line
+			dl = 400.0 / 13.0 if attr[1] == 2 else 400.0 / 31.0
 			ddx = dx * dl
 			ddy = dy * dl
-			while l > dl:
+			while line > dl:
 				vl[-1].append((ox + ddx, oy + ddy))
 				ox += ddx * 2
 				oy += ddy * 2
 				vl.append([ii, (ox, oy)])
-				l -= dl * 2
-			if l > 0:
-				vl[-1].append((ox + l * dx, oy + l * dy))
+				line -= dl * 2
+			if line > 0:
+				vl[-1].append((ox + line * dx, oy + line * dy))
 
 		if attr[1] != 5:
 			vl[-1].append((x, y))
@@ -72,14 +69,14 @@ def vectorlist(wl):
 				siz = int(siz * 2)
 			tl = font.vectors(a & 0x0FF)
 			for i in tl:
-				l = [ii]
+				lines = [ii]
 				for dx, dy in i:
 					ddx = dx * rot[0] + dy * rot[1]
 					ddy = dx * rot[2] + dy * rot[3]
 					x += ddx * siz
 					y += ddy * siz
-					l.append((x, y))
-				vl.append(l)
+					lines.append((x, y))
+				vl.append(lines)
 		elif c == 0x2000:
 			# Graph
 			b = a & 0x7FF
@@ -128,14 +125,16 @@ def writeSvg(fileName: str, wl, scale=0.25):
 			svg.write('  <polyline points="')
 			for x, y in i[1:]:
 				svg.write(
-					f" {(offset + scale * x):.1f},{(scale * (height - y * aspectRatio) + offset):.1f}"
+					f" {(offset + scale * x):.1f}"
+					f",{(scale * (height - y * aspectRatio) + offset):.1f}"
 				)
 			svg.write(f'" stroke="#{c:02x}{c:02x}{c:02x}"')
 			svg.write("/>\n")
 		elif i[0] == 2.0:
 			x, y = i[1]
 			svg.write(
-				f'  <circle cx="{offset + scale * x}" cy="{scale * (height - y * aspectRatio) + offset}"'
+				f'  <circle cx="{offset + scale * x}" '
+				f'cy="{scale * (height - y * aspectRatio) + offset}"'
 			)
 			svg.write(f' r="{(5 * scale):.1f}" fill="black" />\n')
 
@@ -146,19 +145,13 @@ def writeSvg(fileName: str, wl, scale=0.25):
 
 def main():
 	b = bytearray(open("01347-80010.bin", "rb").read())
-	l = []
-	for a in range(0x31E, 0x400, 2):
-		l.append((b[a] << 8) | b[a + 1])
-	writeSvg("_focus.svg", l, 0.3)
+	lines = [(b[a] << 8) | b[a + 1] for a in range(0x31E, 0x400, 2)]
+	writeSvg("_focus.svg", lines, 0.3)
 
-	l = []
-	for a in range(0x122, 0x150, 2):
-		l.append((b[a] << 8) | b[a + 1])
-	for a in range(0x150, 0x200, 2):
-		l.append((b[a] << 8) | b[a + 1])
-	for a in range(0x222, 0x2C8, 2):
-		l.append((b[a] << 8) | b[a + 1])
-	writeSvg("_align.svg", l, 0.3)
+	lines = [(b[a] << 8) | b[a + 1] for a in range(0x122, 0x150, 2)]
+	lines.extend([(b[a] << 8) | b[a + 1] for a in range(0x200, 0x222, 2)])
+	lines.extend([(b[a] << 8) | b[a + 1] for a in range(0x222, 0x2C8, 2)])
+	writeSvg("_align.svg", lines, 0.3)
 
 
 if __name__ == "__main__":

--- a/font/hp1345Font.py
+++ b/font/hp1345Font.py
@@ -33,7 +33,7 @@ class Font:
 			if not stroke[sa] and not stroke[sa + 1]:
 				return
 
-			l = []
+			lines = []
 			while True:
 				if used[sa]:
 					return
@@ -48,19 +48,19 @@ class Font:
 					dy = -dy
 
 				if not stroke[sa] & 0x80:
-					l.append([])
+					lines.append([])
 
-				if len(l) == 0:
-					l.append([(0, 0)])
+				if len(lines) == 0:
+					lines.append([(0, 0)])
 
-				l[-1].append((dx, dy))
+				lines[-1].append((dx, dy))
 
 				if stroke[sa + 1] & 0x80:
 					break
 
 				sa += 2
 
-			self.v[char] = l
+			self.v[char] = lines
 
 		for i in range(128):
 			buildchar(i)

--- a/font/mksvgs.py
+++ b/font/mksvgs.py
@@ -74,26 +74,26 @@ def createGrid(
 	# Make a list of grid lines and sort them by marker
 	# to avoid lighter lines overlapping darker lines.
 
-	l: list[tuple[int, str, int, int, int, int]] = []
+	lines: list[tuple[int, str, int, int, int, int]] = []
 	for x in range(x0, x1 + 1):
 		m = ""
 		for a, b in markers:
 			if x % a == 0:
 				m = b
-		l.append((a, m, x, y0, x, y1))
+		lines.append((a, m, x, y0, x, y1))
 	for y in range(y0, y1 + 1):
 		m = ""
 		for a, b in markers:
 			if y % a == 0:
 				m = b
-		l.append((a, m, x0, y, x1, y))
+		lines.append((a, m, x0, y, x1, y))
 
-	l.sort()
-	writePolylines(svg, ind, l)
+	lines.sort()
+	writePolylines(svg, ind, lines)
 
 
-def writePolylines(svg: TextIOWrapper, ind: int, l: list[tuple[int, str, int, int, int, int]]):
-	for _, b, x0, y0, x1, y1 in l:
+def writePolylines(svg: TextIOWrapper, ind: int, lines: list[tuple[int, str, int, int, int, int]]):
+	for _, b, x0, y0, x1, y1 in lines:
 		svg.write(f'{" " * ind}<polyline points="{x0},{y0} {x1},{y1}" {b} />\n')
 
 
@@ -206,10 +206,7 @@ def makeSvgString(
 	svg.write(f'	<g stroke-width="{fontThickness}" stroke="{fontColour}">\n')
 	x, y = 0, 0
 
-	if drawShadow:
-		shadow = 'stroke-width=".4" stroke="#99eeee"'
-	else:
-		shadow = None
+	shadow = 'stroke-width=".4" stroke="#99eeee"' if drawShadow else None
 
 	for char in ss:
 		x, y = polylines(
@@ -317,7 +314,7 @@ def saveCharsToTable(font: Font):
 	svg.write(">\n")
 
 	svg.write('	<g stroke="#000000">\n')
-	for i in range(0, 16):
+	for i in range(16):
 		b = bytearray("-%x".encode("ascii") % i)
 		x = 5
 		y = (15 - i) * grid + 10
@@ -355,7 +352,8 @@ def saveCharsToTable(font: Font):
 			scy = (grid - 0.0) / (boundingBox[3] - boundingBox[1])
 			sc = min(scx, scy, 1.8)
 			svg.write(
-				f' transform="matrix({sc:.2f},0,0,{sc:.2f},{x - sc * boundingBox[0]},{y - sc * boundingBox[1]})" '
+				f' transform="matrix({sc:.2f},0,0,{sc:.2f},{x - sc * boundingBox[0]},'
+				f'{y - sc * boundingBox[1]})" '
 			)
 			svg.write(" >\n")
 			polylines(svg, 10, font, char)

--- a/gnss/nmea.py
+++ b/gnss/nmea.py
@@ -13,8 +13,8 @@ class GnssData:
 	satellites: list[SatelliteInView] = field(default_factory=list)
 	latitude: float = 0
 	longitude: float = 0
-	date: datetime = datetime.fromtimestamp(0)
-	lastRecordedTime: datetime = datetime.fromtimestamp(0)
+	date: datetime = field(default_factory=lambda: datetime.fromtimestamp(0))
+	lastRecordedTime: datetime = field(default_factory=lambda: datetime.fromtimestamp(0))
 	altitude: float = 0
 	altitudeUnit: str = "M"
 	geoidSeparation: float = 0
@@ -50,25 +50,26 @@ def filterMessagesToType(nmeaMessages: list[NMEAMessage], messageType: str) -> l
 def parseSatelliteInMessage(parsedData: NMEAMessage, updateTime: datetime) -> list[SatelliteInView]:
 	"""Parse a GSV message into a list of SatelliteInView objects"""
 	if parsedData.msgID != "GSV":
-		raise ValueError(f"Expected GSV message, got {parsedData.msgID}")
+		msg = f"Expected GSV message, got {parsedData.msgID}"
+		raise ValueError(msg)
 
 	return [
 		SatelliteInView(
-			prnNumber=getattr(parsedData, f"svid_0{satNum+1}"),
+			prnNumber=getattr(parsedData, f"svid_0{satNum + 1}"),
 			network=parsedData.talker,
-			elevation=tryParseFloat(getattr(parsedData, f"elv_0{satNum+1}")),
-			azimuth=tryParseFloat(getattr(parsedData, f"az_0{satNum+1}")),
-			snr=tryParseFloat(getattr(parsedData, f"cno_0{satNum+1}")),
+			elevation=tryParseFloat(getattr(parsedData, f"elv_0{satNum + 1}")),
+			azimuth=tryParseFloat(getattr(parsedData, f"az_0{satNum + 1}")),
+			snr=tryParseFloat(getattr(parsedData, f"cno_0{satNum + 1}")),
 			lastSeen=updateTime,
 			previousPositions=[
 				(
-					tryParseFloat(getattr(parsedData, f"elv_0{satNum+1}")),
-					tryParseFloat(getattr(parsedData, f"az_0{satNum+1}")),
+					tryParseFloat(getattr(parsedData, f"elv_0{satNum + 1}")),
+					tryParseFloat(getattr(parsedData, f"az_0{satNum + 1}")),
 				)
 			],
 		)
 		for satNum in range(3)
-		if hasattr(parsedData, f"svid_0{satNum+1}")
+		if hasattr(parsedData, f"svid_0{satNum + 1}")
 	]
 
 

--- a/gnss/satellite.py
+++ b/gnss/satellite.py
@@ -16,7 +16,7 @@ class SatelliteInView:
 	azimuth: float = 0
 	previousPositions: list[tuple[float, float]] = field(default_factory=list)
 	snr: float = 0
-	lastSeen: datetime = datetime.fromtimestamp(0)
+	lastSeen: datetime = field(default_factory=lambda: datetime.fromtimestamp(0))
 
 	def toJSON(self, measuredFromLat: float, measuredFromLong: float) -> dict[str, Any]:
 		"""Return data as dictionary to be converted to json"""
@@ -55,7 +55,8 @@ def groupSatellitesByPrn(satellites: list[SatelliteInView]) -> dict[int, list[Sa
 	return satellitesByPrn
 
 
-def colourForNetwork(network: str, palette: Palette = loadPalette()) -> str:
+def colourForNetwork(network: str, palette: Palette = None) -> str:
+	palette = palette or loadPalette()
 	networkName = networkCodeToName(network)
 	if networkName in palette.satelliteNetworks:
 		return palette.satelliteNetworks[networkName]
@@ -84,10 +85,8 @@ def orbitHeightForNetwork(network: str) -> float:
 			return 20.18
 		case "GL":  # GLONASS
 			return 19.13
-		case (
-			"BD"
-			| "GB"
-		):  # BeiDou (todo: there appears to be satellites at a few different orbit heights)
+		case ("BD" | "GB"):
+			# BeiDou (todo: there appears to be satellites at a few different orbit heights)
 			return 21.528
 		case _:  # something else I need to add
 			print(network)
@@ -163,7 +162,9 @@ def quadraticFormula(a: float, b: float, c: float) -> tuple[float, float]:
 
 
 def xyzToLatLong(x: float, y: float, z: float) -> tuple[float, float]:
-	"""Projecting from the xyz coordinates to the lat long coordinates. XYZ should be in the range [-1, 1]"""
+	"""Projecting from the xyz coordinates to the lat long coordinates. XYZ should be in the range
+	[-1, 1]
+	"""
 	lat = math.degrees(math.asin(x))
 	long = math.degrees(math.atan2(z, y))
 	return (lat, long)

--- a/main.py
+++ b/main.py
@@ -39,7 +39,6 @@ def main():
 
 	palette = loadPalette(appConfig.paletteName)
 	windows = []
-	count = 0
 	for windowConfig in appConfig.windows:
 		if isinstance(windowConfig, MapConfig):
 			window = MapWindow(palette, windowConfig)
@@ -56,11 +55,11 @@ def main():
 			window.load(QUrl("http://0.0.0.0:2024/"))
 			window.show()
 		else:
-			raise ValueError(f"Unknown window type: {windowConfig.type}")
+			msg = f"Unknown window type: {windowConfig.type}"
+			raise ValueError(msg)
 		windows.append(window)
 		# if appConfig.multiScreen:
 		# 	handleMultiScreen(screens, window, count)
-		count += 1
 
 	onNewDataCallback = genWindowCallback(windows)
 	createMqttSubscriberClient(appConfig, onNewDataCallback)

--- a/misc/mqtt.py
+++ b/misc/mqtt.py
@@ -39,8 +39,7 @@ def createMqttPublisherClient(config: Config) -> MqttClient:
 	"""Create the publisher MQTT client"""
 	mqttClient = MqttClient(mqttEnums.CallbackAPIVersion.VERSION2, client_id="publisher")
 
-	publisherPassword = os.environ.get("GNSS_PUBLISHER_PASSWORD")
-	if publisherPassword:
+	if publisherPassword := os.environ.get("GNSS_PUBLISHER_PASSWORD"):
 		mqttClient.username_pw_set("gnssreceiver", publisherPassword)
 
 	mqttClient.on_disconnect = onDisconnect
@@ -84,7 +83,9 @@ def onDisconnect(
 	_reasonCode: ReasonCode,
 	_properties: Properties,
 ):
-	"""Exit the program if the MQTT broker disconnects, as attempting to reconnect doesn't seem to work"""
+	"""Exit the program if the MQTT broker disconnects, as attempting to reconnect does not seem to
+	work
+	"""
 	print("Disconnected from MQTT broker. Don't Panic!")
 	tryReconnect(client)
 

--- a/misc/scrape.py
+++ b/misc/scrape.py
@@ -19,8 +19,7 @@ def main():
 def scrapeFile(url):
 	print(f"Fetching {url}")
 	with urllib.request.urlopen(url) as gzippedFile:
-		file = gzip.decompress(gzippedFile.read()).decode("utf-8")
-		return file
+		return gzip.decompress(gzippedFile.read()).decode("utf-8")
 
 
 def fetchAndSaveLatestData(beforeDate: datetime):
@@ -41,14 +40,9 @@ def gpsCsvToDict(csv: str) -> dict[str, tuple[int, int]]:
 	"""Convert the given gpsJam CSV to a dict of h3 hexes to (lat, long) tuples"""
 	h3Dict = {}
 	for line in csv.split("\n"):
-		if line.startswith("hex"):
-			continue
-		if line == "":
-			continue
-		line = line.split(",")
-		good = int(line[1])
-		bad = int(line[2])
-		h3Dict[line[0]] = (good, bad)
+		if line and not line.startswith("hex"):
+			key, good, bad = line.split(",")[:3]
+			h3Dict[key] = (int(good), int(bad))
 	return h3Dict
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,16 @@
+[tool.codespell]
+ignore-words-list = "siz"
+skip = "*.geojson,*.lock,*.svg,./views/map/*.txt"
+
 [tool.ruff]
 line-length = 100
+lint.select = ["B", "C4", "C90", "E", "F", "ICN", "PERF", "PIE", "PL", "RET", "RUF", "SIM", "W"]
+lint.ignore = ["SIM115", "W191"]
+lint.mccabe.max-complexity = 21
+lint.pylint.allow-magic-value-types = ["float", "int", "str"]
+lint.pylint.max-args = 10  # Default is 5
+lint.pylint.max-branches = 15  # Default is 12
+lint.pylint.max-statements = 72  # Default is 50
 
 [tool.ruff.format]
 indent-style = "tab"

--- a/receiver/serialMonitor.py
+++ b/receiver/serialMonitor.py
@@ -8,7 +8,8 @@ def getSerialLocation() -> str:
 	"""Get the serial location of the receiver"""
 	serialLocation = "/dev/ttyUSB0"  # default to linux, TODO ACM0
 	if os.name == "nt":
-		serialLocation = "COM4"  # on windows, COM4 is default for my receiver? although the other one defaults to COM3
+		# on windows, COM4 is default for my receiver? although the other one defaults to COM3
+		serialLocation = "COM4"
 	return serialLocation
 
 

--- a/scripts/mqtTest.py
+++ b/scripts/mqtTest.py
@@ -1,6 +1,6 @@
 import time
 from typing import Any
-from matplotlib import pyplot
+from matplotlib import pyplot as plt
 import paho.mqtt.enums as mqttEnums
 from paho.mqtt.client import Client as MqttClient, MQTTMessage
 from dotenv import load_dotenv
@@ -9,7 +9,7 @@ from misc.mqtt import createMqttPublisherClient
 
 
 def main():
-	"""Send a bunch of messages to the MQTT broker and measure how long each of these 'ping's takes"""
+	"""Send numerous messages to the MQTT broker and measure how long each of these 'ping's takes"""
 	load_dotenv()
 	config = loadConfig()
 	publisher = createMqttPublisherClient(config)
@@ -22,8 +22,8 @@ def main():
 		if timeMs < 80:
 			times.append(timeMs)
 
-	pyplot.hist(times, bins=100)
-	pyplot.show()
+	plt.hist(times, bins=100)
+	plt.show()
 
 
 def createMqttClient(config: Config) -> MqttClient:

--- a/tests/test_cities.py
+++ b/tests/test_cities.py
@@ -1,5 +1,5 @@
 # pylint: skip-file
-from map.cities import findNearestCityWithCache
+from views.map.cities import findNearestCityWithCache
 
 
 def test_finds_nearest_city():

--- a/views/map/cities.py
+++ b/views/map/cities.py
@@ -39,14 +39,12 @@ def filterToPopPercent(
 	""":param citiesInCountry: sorted list of cities in a country"""
 	countryPop = float(countryInfo[7])
 	addedPop = 0
-	addedCount = 0
 
 	filteredCities = []
-	for city in citiesInCountry:
+	for addedCount, city in enumerate(citiesInCountry, 1):
 		filteredCities.append(city)
 
 		addedPop += int(city[14])
-		addedCount += 1
 
 		if addedPop > countryPop * percent and addedCount > minCities:
 			break
@@ -64,7 +62,9 @@ def sortCitiesByPop(citiesInCountry: list[list[str]]):
 
 
 def calcMaxNumCitiesToInclude(countryInfo: list[str]) -> int:
-	"""Calculate the maximum number of cities to include in a country, based on both its population and area"""
+	"""Calculate the maximum number of cities to include in a country, based on both its population
+	and area
+	"""
 	extraCityPerMillion = 0.05
 	extraCityPerThousandKm2 = 0.05
 
@@ -76,11 +76,10 @@ def calcMaxNumCitiesToInclude(countryInfo: list[str]) -> int:
 def readCityInfo() -> dict[str, list[list[str]]]:
 	"""Read the city info from the file and group it by country"""
 	rawCityInfo = readTSV("./views/map/cities15000.txt")
-	cityInfo = {
+	return {
 		country: list(cities)
 		for country, cities in itertools.groupby(rawCityInfo, key=lambda x: x[8])
 	}
-	return cityInfo
 
 
 def findNearestCity(lat: float, long: float, file: str = "./views/map/cities15000.txt"):
@@ -134,8 +133,7 @@ def distBetweenPoints(lat1: float, long1: float, lat2: float, long2: float) -> f
 
 def readCountryInfo() -> dict[str, list[str]]:
 	rawCountryInfo = readTSV("./views/map/countryInfo.txt")
-	countryInfo = {row[0]: row for row in rawCountryInfo}  # key is the country code
-	return countryInfo
+	return {row[0]: row for row in rawCountryInfo}  # key is the country code
 
 
 def readTSV(filename: str) -> list[list[str]]:

--- a/views/map/generate.py
+++ b/views/map/generate.py
@@ -25,7 +25,7 @@ def prepareInitialMap(mapSvg: str, palette: Palette, options: MapConfig) -> tupl
 	if not options.hideCities:
 		mapSvg = mapSvg.replace("</svg>", genCitiesGroup(mapSize, options, palette) + "\n</svg>")
 
-	# add comment for where sattelites will go
+	# add comment for where satellites will go
 	mapSvg = mapSvg.replace("</svg>", "\n<!-- satellites go here -->\n</svg>")
 
 	# key (will be hidden later if needed)

--- a/views/map/update.py
+++ b/views/map/update.py
@@ -81,7 +81,7 @@ def generateSatelliteTrails(
 	]
 	mapPoints = [latLongToGallStereographic(lat, long, mapSize.width) for lat, long in latLongs]
 
-	# split into seperate polylines when distance too big (e.g. crossing antimeridian)
+	# split into separate polylines when distance too big (e.g. crossing antimeridian)
 	mapPointsSplit: list[list[tuple[float, float]]] = []
 	for index, point in enumerate(mapPoints):
 		if (
@@ -186,6 +186,7 @@ def calcNewDimensions(
 				newHeight = mapSize.height / scaleFactor
 				newWidth = newHeight * desiredSize.width / desiredSize.height
 		case _:
-			raise ValueError(f"Invalid scale method: {scaleMethod}")
+			msg = f"Invalid scale method: {scaleMethod}"
+			raise ValueError(msg)
 
 	return Size(newWidth, newHeight)

--- a/views/map/window.py
+++ b/views/map/window.py
@@ -55,7 +55,7 @@ class MapWindow(QMainWindow):
 		)
 		mapSvg = self.initialMap.replace("<!-- satellites go here -->", satelliteGroup)
 		self.preFocusMap = mapSvg
-		mapSvg = focusOnPoint(
+		return focusOnPoint(
 			mapSvg,
 			self.windowConfig,
 			Size(self.map.width(), self.map.height()),
@@ -63,7 +63,6 @@ class MapWindow(QMainWindow):
 			self.keyXMult,
 			self.keyYMult,
 		)
-		return mapSvg
 
 	def resizeEvent(self, event: QResizeEvent):
 		"""Resize map when window is resized"""

--- a/views/polarGrid/generate.py
+++ b/views/polarGrid/generate.py
@@ -11,6 +11,4 @@ def prepareIntialPolarGrid(svgData: str, palette: Palette) -> str:
 	svgData = svgData.replace('viewBox="0 0 94 94"', 'viewBox="-2 -2 98 98"')
 	svgData = svgData.replace('fill="#fff"', f'fill="{palette.background}"')
 	svgData = svgData.replace('stroke="#aaa"', f'stroke="{palette.polarGrid}"')
-	svgData = svgData.replace('stroke="#000"', f'stroke="{palette.polarGrid}" style="display:none"')
-
-	return svgData
+	return svgData.replace('stroke="#000"', f'stroke="{palette.polarGrid}" style="display:none"')

--- a/views/polarGrid/update.py
+++ b/views/polarGrid/update.py
@@ -25,6 +25,4 @@ def addSatellitesToPolarGrid(
 		satelliteStr += f'<circle cx="{x}" cy="{y}" r="2" fill="{colour}" />'
 	satelliteStr += "</g></svg>"
 
-	svgData = svgData.replace("</svg>", satelliteStr)
-
-	return svgData
+	return svgData.replace("</svg>", satelliteStr)

--- a/views/stats/generate.py
+++ b/views/stats/generate.py
@@ -41,8 +41,8 @@ def generateStats(
 
 	strToDisplay = f"""Lat: {data.latitude:.6f}
 Long: {data.longitude:.6f}
-Date: {data.date.strftime('%Y-%m-%d')}
-Time: {data.date.strftime('%H:%M:%S')}
+Date: {data.date.strftime("%Y-%m-%d")}
+Time: {data.date.strftime("%H:%M:%S")}
 City: {nearestCity}
 Altitude: {data.altitude:.1f}{data.altitudeUnit.lower()}
 Geoid Separation: {data.geoidSeparation:.1f}{data.geoidSeparationUnit.lower()}

--- a/web/background.py
+++ b/web/background.py
@@ -30,6 +30,7 @@ baseMap, keySize = prepareInitialMap(baseMap, PALETTE, mapConfig)
 basePolarGrid = readBasePolarGrid()
 basePolarGrid = prepareIntialPolarGrid(basePolarGrid, PALETTE)
 
+# ruff: noqa: PLW0603
 LATEST_DATA = None
 
 

--- a/web/satelliteDisplay.ts
+++ b/web/satelliteDisplay.ts
@@ -47,7 +47,7 @@ pre {
 
 		this.shadowRoot!.getElementById("satelliteInfo")!.innerText = `PRN: ${satellite.prnNumber}
 Orbit height: ${satellite.altitude}km
-Dist from reciever: ${distToSatellite}km
+Dist from receiver: ${distToSatellite}km
 Network: ${satellite.network}
 Lat: ${roundLat}
 Long: ${roundLong}


### PR DESCRIPTION
Find typos with codespell and apply more ruff linting rules.
* https://github.com/codespell-project/codespell#readme
* https://docs.astral.sh/ruff

Advise:
* Try to reduce single-letter variable names.  They are not self-documenting and make for 1970s-style code.
* It is Python so use snake_case for variable names, etc.  https://docs.astral.sh/ruff/rules/#pep8-naming-n
* It is Python so drop the tab indentation.  `tool.ruff.format.indent-style`